### PR TITLE
Fix delete catalog modal not closing after successful deletion

### DIFF
--- a/src/components/admin/CatalogOptions.tsx
+++ b/src/components/admin/CatalogOptions.tsx
@@ -106,7 +106,10 @@ export default function CatalogOptions({ catalog, onUpdate }: Props) {
         <DeleteCatalogModal
           catalog={catalog}
           onClose={() => setShowDeleteModal(false)}
-          onSuccess={onUpdate}
+          onSuccess={() => {
+            setShowDeleteModal(false);
+            onUpdate();
+          }}
         />
       )}
     </>


### PR DESCRIPTION
The onSuccess callback for DeleteCatalogModal only called onUpdate (fetchCatalogs)
but never closed the modal, leaving it open after a catalog was deleted.

https://claude.ai/code/session_01U2H8oQXTJgq5Wb3tscvMFY